### PR TITLE
Implement fade-out when quitting game

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,9 +76,13 @@
           .setOrigin(1, 1)
           .setInteractive();
 
-        // ボタン押下でリザルトシーンへ
+        // ボタン押下でフェードアウト後タイトルへ戻る
         this.endText.on('pointerdown', () => {
-          this.scene.start('ResultScene', { score: this.score });
+          this.endText.disableInteractive();
+          this.cameras.main.once('camerafadeoutcomplete', () => {
+            this.scene.start('TitleScene');
+          });
+          this.cameras.main.fade(500, 0, 0, 0);
         });
 
         // タイマー（1秒ごと更新）


### PR DESCRIPTION
## Summary
- add camera fade effect when pressing the "終了" button
- return directly to the title screen after fade completes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fe73356d8832194766889c11436d8