### PR TITLE
Fix logo size and add transparency

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,10 @@ class TitleScene extends Phaser.Scene {
     this.load.image('zombieLogo', 'logo.png');
   }
   create() {
-    this.add.image(400, 140, 'zombieLogo').setScale(4);
+      this.add
+        .image(400, 140, 'zombieLogo')
+        .setScale(0.5)
+        .setAlpha(0.5);
         this.add.text(400, 200, 'Typing of the Dot', { fontSize: '32px', fill: '#0f0' }).setOrigin(0.5);
         this.add.text(400, 250, '~ Fight the Pixel Undead ~', { fontSize: '16px', fill: '#ccc' }).setOrigin(0.5);
 


### PR DESCRIPTION
## Summary
- shrink title logo so it fits within the game
- set the title logo transparency to 50%

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683ffcd27d148321ab5db44ef2c3fdc9