### PR TITLE
Adjust title image position and opacity

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,9 @@ class TitleScene extends Phaser.Scene {
   }
   create() {
       this.add
-        .image(400, 140, 'zombieLogo')
+        .image(400, 300, 'zombieLogo')
         .setScale(0.5)
-        .setAlpha(0.5);
+        .setAlpha(0.8);
         this.add.text(400, 200, 'Typing of the Dot', { fontSize: '32px', fill: '#0f0' }).setOrigin(0.5);
         this.add.text(400, 250, '~ Fight the Pixel Undead ~', { fontSize: '16px', fill: '#ccc' }).setOrigin(0.5);
 


### PR DESCRIPTION
## Summary
- center the title scene image
- set title image to 80% opacity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ffe401a90832199c8052b4b10ecc6