### PR TITLE
Adjust title scene transparency

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ class TitleScene extends Phaser.Scene {
       this.add
         .image(400, 300, 'zombieLogo')
         .setScale(0.5)
-        .setAlpha(0.8);
+        .setAlpha(0.85);
         this.add.text(400, 200, 'Typing of the Dot', { fontSize: '32px', fill: '#0f0' }).setOrigin(0.5);
         this.add.text(400, 250, '~ Fight the Pixel Undead ~', { fontSize: '16px', fill: '#ccc' }).setOrigin(0.5);
 


### PR DESCRIPTION
## Summary
- make the title logo slightly more transparent to match a 15% transparency rate

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fff31f9f08321bcca8f5912713636