### PR TITLE
Adjust title screen layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,16 +28,14 @@ class TitleScene extends Phaser.Scene {
   }
   create() {
       this.add
-        .image(400, 300, 'zombieLogo')
+        .image(400, 120, 'zombieLogo')
         .setScale(0.5)
-        .setAlpha(0.8);
-        this.add.text(400, 200, 'Typing of the Dot', { fontSize: '32px', fill: '#0f0' }).setOrigin(0.5);
-        this.add.text(400, 250, '~ Fight the Pixel Undead ~', { fontSize: '16px', fill: '#ccc' }).setOrigin(0.5);
+        .setAlpha(1);
 
         const best = parseInt(localStorage.getItem('bestScore')) || 0;
-        this.add.text(400, 300, `ベストスコア: ${best}`, { fontSize: '18px', fill: '#ff0' }).setOrigin(0.5);
+        this.add.text(400, 220, `ベストスコア: ${best}`, { fontSize: '18px', fill: '#ff0' }).setOrigin(0.5);
 
-        const startText = this.add.text(400, 350, '▶︎ ゲーム開始', { fontSize: '24px', fill: '#0ff' })
+        const startText = this.add.text(400, 280, '▶︎ ゲーム開始', { fontSize: '24px', fill: '#0ff' })
           .setOrigin(0.5)
           .setInteractive();
 


### PR DESCRIPTION
## Summary
- move the title logo to the upper center without transparency
- remove unused tagline lines
- display best score and start prompt underneath the logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fff31f9f08321bcca8f5912713636