### PR TITLE
Move title texts below game

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,14 +27,25 @@ class TitleScene extends Phaser.Scene {
     this.load.image('zombieLogo', 'logo.png');
   }
   create() {
+      const { width, height } = this.scale;
+
       this.add
-        .image(400, 100, 'zombieLogo')
+        .image(width / 2, height * 0.25, 'zombieLogo')
         .setScale(0.5);
 
       const best = parseInt(localStorage.getItem('bestScore')) || 0;
-      this.add.text(400, 180, `ベストスコア: ${best}`, { fontSize: '18px', fill: '#ff0' }).setOrigin(0.5);
+      this.add
+        .text(width / 2, height - 120, `ベストスコア: ${best}`, {
+          fontSize: '18px',
+          fill: '#ff0'
+        })
+        .setOrigin(0.5);
 
-      const startText = this.add.text(400, 230, '▶︎ ゲーム開始', { fontSize: '24px', fill: '#0ff' })
+      const startText = this.add
+        .text(width / 2, height - 70, '▶︎ ゲーム開始', {
+          fontSize: '24px',
+          fill: '#0ff'
+        })
         .setOrigin(0.5)
         .setInteractive();
 


### PR DESCRIPTION
## Summary
- reposition title image near top
- display best score and start text near bottom of screen so the logo doesn't overlap

## Testing
- `npx --yes serve` (manual verification)

------
https://chatgpt.com/codex/tasks/task_e_684003d53eb08321ac92b2f5c9562a73