### PR TITLE
Fix ranking submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,17 +196,17 @@ class ResultScene extends Phaser.Scene {
       localStorage.setItem('bestScore', this.finalScore);
       this.add.text(440, 330, '新記録！', { fontSize: '18px', fill: '#0ff' }).setOrigin(0.5);
       this.add.text(440, 363, `ベストスコア: ${this.finalScore}`, { fontSize: '18px', fill: '#ff0' }).setOrigin(0.5);
-
-      const name = prompt('名前を入力してください');
-      if (name) {
-        await fetch('/ranking', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name, score: this.finalScore })
-        });
-      }
     } else {
       this.add.text(440, 330, `ベストスコア: ${best}`, { fontSize: '18px', fill: '#ff0' }).setOrigin(0.5);
+    }
+
+    const name = prompt('名前を入力してください');
+    if (name) {
+      await fetch('/ranking', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, score: this.finalScore })
+      });
     }
 
     const restartText = this.add.text(440, 385, '▶︎ もう一度プレイ', { fontSize: '20px', fill: '#0f0' })


### PR DESCRIPTION
## Summary
- always prompt for name so game records scores even if you don't beat the top score

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68401a82fc3483219ec98da4bc520975