### PR TITLE
Handle ranking offline storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,13 @@ class ResultScene extends Phaser.Scene {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, score: this.finalScore })
-      });
+      }).catch(() => {});
+
+      const localRanking = JSON.parse(localStorage.getItem('ranking') || '[]');
+      localRanking.push({ name, score: this.finalScore });
+      localRanking.sort((a, b) => b.score - a.score);
+      localRanking.splice(10);
+      localStorage.setItem('ranking', JSON.stringify(localRanking));
     }
 
     const restartText = this.add.text(440, 385, '▶︎ もう一度プレイ', { fontSize: '20px', fill: '#0f0' })
@@ -233,6 +239,15 @@ class RankingScene extends Phaser.Scene {
       }
     } catch (e) {
       console.error('Failed to load ranking', e);
+    }
+
+    if (ranking.length === 0) {
+      const local = localStorage.getItem('ranking');
+      if (local) {
+        try {
+          ranking = JSON.parse(local);
+        } catch {}
+      }
     }
 
     this.add


### PR DESCRIPTION
## Summary
- persist scores locally when posting to `/ranking`
- read local scores in case the server ranking is unavailable

## Testing
- `npm install`
- `node server.js &` *(fails: module not found, fixed with install)*
- `curl -X POST -H 'Content-Type: application/json' -d '{"name":"Alice","score":68}' http://localhost:3000/ranking`

------
https://chatgpt.com/codex/tasks/task_e_68402c00af848321bfbd35e8bd3755bb